### PR TITLE
Fix for undefined value

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
   "perl" : "6",
   "name" : "JSON::Fast",
   "description" : "A naive, fast json parser and serializer; drop-in replacement for JSON::Tiny",
-  "version" : "0.3",
+  "version" : "0.4",
   "test-depends" : [
     "Test"
   ],

--- a/lib/JSON/Fast.pm
+++ b/lib/JSON/Fast.pm
@@ -13,6 +13,7 @@ sub str-escape(str $text) {
 sub to-json($obj is copy, Bool :$pretty = True, Int :$level = 0, Int :$spacing = 2) is export {
     return $obj ?? 'true' !! 'false' if $obj ~~ Bool;
     return $obj.Str if $obj ~~ Int|Rat;
+    return 'null' if not $obj.defined;
     return "\"{str-escape($obj)}\"" if $obj ~~ Str;
 
     if $obj ~~ Seq {

--- a/t/04-roundtrip.t
+++ b/t/04-roundtrip.t
@@ -2,7 +2,7 @@ use Test;
 
 use JSON::Fast;
 
-my @s =
+my @s = 
         'Int'            => [ 1 ],
         'Rat'            => [ 3.2 ],
         'Str'            => [ 'one' ],
@@ -14,7 +14,9 @@ my @s =
         'Array of Int'   => [ 1, 2, 3, 123123123 ],
         'Array of Num'   => [ 1.3, 2.8, 32323423.4, 4.0 ],
         'Array of Str'   => [ <one two three gazooba> ],
+        'Array of Undef' => [ Any, Any ],
         'Empty Hash'     => {},
+        'Undef Hash Val' => { key => Any },
         'Hash of Int'    => { :one(1), :two(2), :three(3) },
         'Hash of Num'    => { :one-and-some[1], :almost-pie(3.3) },
         'Hash of Str'    => { :one<yes_one>, :two<but_two> },


### PR DESCRIPTION
Currently it doesn't deal with undefined values:

```
[jonathan@coriolanus JSON-Marshal]$ perl6 -e 'use JSON::Fast; say
to-json({foo => Str})'
Cannot unbox a type object
  in sub str-escape at sources/A670982EBE56A59B3A7611E194FB56A852C763B3
(JSON::Fast) line 5
  in sub to-json at sources/A670982EBE56A59B3A7611E194FB56A852C763B3
(JSON::Fast) line 16
  in sub to-json at sources/A670982EBE56A59B3A7611E194FB56A852C763B3
(JSON::Fast) line 39
  in block <unit> at -e line 1
```

The same applies to Array elements.  

This now works

It is preventing me from switching to JSON::Fast in https://github.com/jonathanstowe/JSON-Marshal which would be a shame as JSON::Unmarshal already did (and my most common use-case is round-tripping objects, as in JSON::Class)

May partially address #4 but the actual example in the issue has a plain Any which still doesn't work for other reasons.
