### PR TITLE
Convert null byte to \u0000, make to-json 2.9x faster

### DIFF
--- a/lib/JSON/Fast.pm
+++ b/lib/JSON/Fast.pm
@@ -3,12 +3,12 @@ use nqp;
 unit module JSON::Fast;
 
 sub str-escape(str $text) {
-  return $text.subst(/'\\'/, '\\\\', :g)\
-              .subst(/"\n"/, '\\n',  :g)\
-              .subst(/"\r"/, '\\r',  :g)\
-              .subst(/"\t"/, '\\t',  :g)\
-              .subst(/'"'/,  '\\"',  :g)\
-              .subst(/\0/, '\\u0000', :g);
+    return $text.subst('\\', '\\\\',    :g)\
+                .subst("\n", '\\n',     :g)\
+                .subst("\r", '\\r',     :g)\
+                .subst("\t", '\\t',     :g)\
+                .subst('"',  '\\"',     :g)\
+                .subst("\0", '\\u0000', :g);
 }
 
 sub to-json($obj is copy, Bool :$pretty = True, Int :$level = 0, Int :$spacing = 2) is export {

--- a/lib/JSON/Fast.pm
+++ b/lib/JSON/Fast.pm
@@ -3,11 +3,12 @@ use nqp;
 unit module JSON::Fast;
 
 sub str-escape(str $text) {
-  return $text.subst(/'\\'/, '\\\\', :g)\ 
+  return $text.subst(/'\\'/, '\\\\', :g)\
               .subst(/"\n"/, '\\n',  :g)\
               .subst(/"\r"/, '\\r',  :g)\
               .subst(/"\t"/, '\\t',  :g)\
-              .subst(/'"'/,  '\\"',  :g);  
+              .subst(/'"'/,  '\\"',  :g)\
+              .subst(/\0/, '\\u0000', :g);
 }
 
 sub to-json($obj is copy, Bool :$pretty = True, Int :$level = 0, Int :$spacing = 2) is export {
@@ -142,7 +143,7 @@ my sub parse-numeric(str $text, int $pos is rw) {
 
         $residual := nqp::substr($text, $pos, 1);
     }
-    
+
     if $residual eq 'e' || $residual eq 'E' {
         $pos = $pos + 1;
 

--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -1,5 +1,6 @@
+#!/usr/bin/env perl6
 use v6;
-
+use lib 'lib';
 use JSON::Fast;
 use Test;
 
@@ -231,4 +232,3 @@ for @n -> $t {
 
 
 # vim: ft=perl6
-

--- a/t/02-structure.t
+++ b/t/02-structure.t
@@ -1,5 +1,6 @@
+#!/usr/bin/env perl6
 use v6;
-
+use lib 'lib';
 use JSON::Fast;
 use Test;
 

--- a/t/03-unicode.t
+++ b/t/03-unicode.t
@@ -1,5 +1,6 @@
+#!/usr/bin/env perl6
 use v6;
-
+use lib 'lib';
 use JSON::Fast;
 use Test;
 
@@ -8,7 +9,7 @@ my @t =
     '{ "a" : "b\u00E5" }' => { 'a' => 'bå' },
     '[ "\u2685" ]' => [ '⚅' ];
 
-my @out = 
+my @out =
     "\{\"a\": \"bå\"}",
     '["⚅"]';
 

--- a/t/04-roundtrip.t
+++ b/t/04-roundtrip.t
@@ -1,8 +1,9 @@
+#!/usr/bin/env perl6
 use Test;
-
+use lib 'lib';
 use JSON::Fast;
 
-my @s = 
+my @s =
         'Int'            => [ 1 ],
         'Rat'            => [ 3.2 ],
         'Str'            => [ 'one' ],


### PR DESCRIPTION
Although we need to make sure all control characters are converted
to be JSON compliant, the null byte is the worst possible character
to accidently put into a JSON file. Let's at least cover this case.

There was some discussion here:
https://irclog.perlgeek.de/perl6/2016-12-14#i_13737067

Had to switch Whateverable to use JSON::Tiny instead, but would be
nice if this was fixed in JSON::Fast

* Use strings with subst instead of regex for 2.9x faster `to-json`
* Also, use #!/usr/bin/env perl6 shebang so that running `prove` will properly run perl6.
* Make sure to `use lib 'lib'`, otherwise if we have JSON::Fast installed already, it will use that version instead of the one in the folder we're running it in.
* Add a test to make sure the null byte is escaped properly