### PR TITLE
Workaround for race conditions in interpolation

### DIFF
--- a/lib/JSON/Fast.pm
+++ b/lib/JSON/Fast.pm
@@ -36,7 +36,7 @@ sub to-json($obj is copy, Bool :$pretty = True, Int :$level = 0, Int :$spacing =
         }
     }
 
-    return "\"{str-escape($obj)}\"" if $obj ~~ Str;
+    return '"'  ~ str-escape( $obj ) ~ '"' if $obj ~~ Str;
 
     if $obj ~~ Seq {
         $obj = $obj.cache

--- a/t/07-race.t
+++ b/t/07-race.t
@@ -1,0 +1,15 @@
+#!/usr/bin/env perl6
+use v6;
+use lib 'lib';
+use JSON::Fast;
+use Test;
+
+plan 1;
+
+my @out = ( '{ "a" : "1" }' xx 10_000 )
+    .race(:degree(8),:batch(1))
+    .map: { to-json( from-json($_) ) };
+
+is @out.elems, 10_000, 'right number of items';
+
+# vim: ft=perl6


### PR DESCRIPTION
This seems to help with #24 .  The root cause seems to be somewhere in interpolation; I haven't been able to isolate it, but this seems to successfully work around it.

I've tested this on the latest build (rakudo 2017.06-226-g5196e0c) (output below)  The test still only fails intermittently :-(

Closes #24 

```
json_fast: (master) perl6 /tmp/07-race.t
1..1
This type cannot unbox to a native string: P6opaque, Hash
  in sub str-escape at /home/bduggan/json_fast/lib/JSON/Fast.pm (JSON::Fast) line 5
  in sub to-json at /home/bduggan/json_fast/lib/JSON/Fast.pm (JSON::Fast) line 39
  in sub to-json at /home/bduggan/json_fast/lib/JSON/Fast.pm (JSON::Fast) line 61
  in block  at /tmp/07-race.t line 11

not ok 1 - right number of items

# Failed test 'right number of items'
# at /tmp/07-race.t line 13
# expected: '10000'
#      got: '9999'
# Looks like you failed 1 test of 1
json_fast: (master) git co race
Switched to branch 'race'
Your branch is up-to-date with 'bduggan/race'.
json_fast: (race) perl6 /tmp/07-race.t
1..1
ok 1 - right number of items
json_fast: (race) perl6 /tmp/07-race.t
1..1
ok 1 - right number of items
json_fast: (race) perl6 /tmp/07-race.t
1..1
ok 1 - right number of items
json_fast: (race) perl6 /tmp/07-race.t
1..1
ok 1 - right number of items
json_fast: (race) perl6 /tmp/07-race.t
1..1
ok 1 - right number of items
json_fast: (race) perl6 -v
This is Rakudo version 2017.06-226-g5196e0c built on MoarVM version 2017.06-70-ga3a58c8
implementing Perl 6.c.

```