### PR TITLE
Using nqp::ord(at) everywhere else, why not here?

### DIFF
--- a/lib/JSON/Fast.pm
+++ b/lib/JSON/Fast.pm
@@ -486,7 +486,7 @@ my sub parse-thing(str $text, int $pos is rw) {
 
     $pos = $pos + 1;
 
-    if ord($initial) == 34 { # "
+    if nqp::ord($initial) == 34 { # "
         parse-string($text, $pos);
     } elsif $initial eq '[' {
         parse-array($text, $pos);


### PR DESCRIPTION
Seems to have a positive effect on speed, as one sub call less for *each* thing