### PR TITLE
Unpretty to-json does not need space after key

### DIFF
--- a/lib/JSON/Fast.pm6
+++ b/lib/JSON/Fast.pm6
@@ -196,7 +196,7 @@ our sub to-json(
         my int $before = nqp::elems(@out);
         for pairs {
             jsonify(.key);
-            nqp::push_s(@out,": ");
+            nqp::push_s(@out,":");
             jsonify(.value);
             nqp::push_s(@out,$comma);
         }

--- a/t/03-unicode.t
+++ b/t/03-unicode.t
@@ -13,10 +13,10 @@ my @t =
     '[ "\ud83c\udded\ud83c\uddf7" ]' => [ "🇭🇷" ];
 
 my @out =
-    "\{\"a\": \"bå\"}",
+    "\{\"a\":\"bå\"}",
     '["⚅"]',
     '["̅hello"]',
-    '{"̅hello": "goodbye"}',
+    '{"̅hello":"goodbye"}',
     '["\uD83C\uDDED\uD83C\uDDF7"]';
 
 plan (+@t * 2 + 2 + 2);


### PR DESCRIPTION
This saves about 200K on my 5M JSON file.