### PR TITLE
Fix precedende bug in Unicode escaping decode

### DIFF
--- a/lib/JSON/Fast.pm6
+++ b/lib/JSON/Fast.pm6
@@ -474,7 +474,7 @@ my sub parse-string(str $text, int $pos is rw) {
                     my str @caps = $/.caps>>.value>>.Str;
                     my $result = $/;
                     my str $endpiece = "";
-                    if my $lastchar = nqp::chr(nqp::ord(@caps.tail)) ne @caps.tail {
+                    if (my $lastchar = nqp::chr(nqp::ord(@caps.tail))) ne @caps.tail {
                         $endpiece = tear-off-combiners(@caps.tail, 0);
                         @caps.pop;
                         @caps.push($lastchar);


### PR DESCRIPTION
Without parentheses it is executed like `my $lastchar = $char ne @caps.tail`,
which might be True and `@caps.push(True)` will lead to an exception,
even though the escape string is totally valid.