### PR TITLE
jsonify Rational just like FatRat; jsonify other Real types via .Bridge

### DIFF
--- a/lib/JSON/Fast.pm6
+++ b/lib/JSON/Fast.pm6
@@ -314,6 +314,9 @@ our sub to-json(
             elsif nqp::istype($_, Instant) {
                 nqp::push_s(@out,qq/"{.DateTime}"/);
             }
+            elsif nqp::istype($_, Real) {
+                jsonify(.Bridge);
+            }
             elsif nqp::istype($_, Version) {
                 jsonify(.Str);
             }

--- a/lib/JSON/Fast.pm6
+++ b/lib/JSON/Fast.pm6
@@ -279,6 +279,10 @@ our sub to-json(
                 nqp::push_s(@out,.contains(".") ?? $_ !! "$_.0")
                   given .Str;
             }
+            elsif nqp::istype($_, Rational) {
+                nqp::push_s(@out,.contains(".") ?? $_ !! "$_.0")
+                  given .Str;
+            }
             elsif nqp::istype($_, Num) {
                 if nqp::isnanorinf($_) {
                     nqp::push_s(

--- a/t/04-roundtrip.t
+++ b/t/04-roundtrip.t
@@ -19,6 +19,8 @@ my @s =
         'Int Allomorph'  => [ IntStr.new(0, '') ] => [ 0 ],
         'Rat Allomorph'  => [ RatStr.new(0.0, '') ] => [0.0],
         'Num Allomorph'  => [ NumStr.new(0e0, '') ] => [0e0],
+        'Duration'       => [ Duration.new(57) ] => [ 5.7e1 ],
+        'Rational'       => [ Rational[Int,Int].new(3,10) ] => [ 0.3 ],
         'Empty Hash'     => {},
         'Undef Hash Val' => { key => Any },
         'Hash of Int'    => { :one(1), :two(2), :three(3) },


### PR DESCRIPTION
Any Real not specifically handled on another path gets one more shot to
successfully jsonify via .Bridge.  This allows for instance Duration to
encode as a Num and thus do approximately the right thing, within the
limits of the JSON data model.