### PR TITLE
Add support for JSONC

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for JSON-Fast
 
 {{$NEXT}}
+    - Add support for JSONC (aka JSON with C-style comments)
 
 0.17  2022-02-10T18:40:34+01:00
     - Add :immutable parameter to "from-json"

--- a/META6.json
+++ b/META6.json
@@ -29,5 +29,5 @@
   "test-depends": [
     "Test"
   ],
-  "version": "0.17"
+  "version": "0.18"
 }

--- a/lib/JSON/Fast.pm6
+++ b/lib/JSON/Fast.pm6
@@ -7,6 +7,8 @@ Currently it seems to be about 4x faster and uses up about a quarter of the RAM 
 
 This module also includes a very fast to-json function that tony-o created and lizmat later completely refactored.
 
+And now also supports L<JSONC|https://changelog.com/news/jsonc-is-a-superset-of-json-which-supports-comments-6LwR>.
+
 =head2 Exported subroutines
 
 =head3 to-json
@@ -389,8 +391,41 @@ module JSON::Fast:ver<0.17> {
     my sub nom-ws(str $text, int $pos is rw --> Nil) {
         nqp::while(
           nqp::atpos_i($ws, nqp::ordat($text, $pos)),
-          $pos = nqp::add_i($pos, 1)
-        )
+          ++$pos
+        );
+        nqp::if(
+          nqp::iseq_i(nqp::ordat($text,$pos),47),  # /
+          nom-comment($text,++$pos)
+        );
+    }
+
+    my sub nom-comment(str $text, int $pos is rw --> Nil) {
+        my int $ordinal = nqp::ordat($text, $pos);
+        nqp::if(
+          nqp::iseq_i(nqp::ordat($text,$pos),47),           # /
+          nqp::stmts(
+            nqp::while(  # eating a // style comment
+              nqp::isne_i(nqp::ordat($text,++$pos),10),       # not \n
+              nqp::null
+            ),
+            nom-ws($text, ++$pos)
+          ),
+          nqp::if(
+            nqp::iseq_i(nqp::ordat($text,$pos),42),           # *
+            nqp::stmts(
+              nqp::until(  # eating a /*  */ style comment
+                nqp::iseq_i(nqp::ordat($text,++$pos),47)      # /
+                  && nqp::iseq_i(
+                       nqp::ordat($text,nqp::sub_i($pos,1)),  # *
+                       42
+                     ),
+                nqp::null
+              ),
+              nom-ws($text, ++$pos)
+            ),
+            die-unexpected-object($text, $pos)
+          )
+        );
     }
 
     my $hexdigits := nqp::list;

--- a/t/14-comments.t
+++ b/t/14-comments.t
@@ -1,0 +1,24 @@
+use JSON::Fast;
+use Test;
+
+plan 1;
+
+my $json := Q:to/JSON/;
+{
+  /* This is an example
+     for block comment */
+  "foo": "bar foo",  // Comments can
+  "true": false,     // Improve readbility
+  "number": 42,      // Number will always be 42
+  /* Comments ignored while
+     generating JSON from JSONC:  */
+  // "object": {
+  //   "test": "done"
+  // },
+  "array": [1, 2, 3]
+}
+JSON
+
+is-deeply from-json($json),
+  {:array($[1, 2, 3]), :foo("bar foo"), :number(42), :true(Bool::False)},
+  'did it parse ok, despite comments';


### PR DESCRIPTION
At the expense of one extra check for each time whitespace is being nommed.

See: https://changelog.com/news/jsonc-is-a-superset-of-json-which-supports-comments-6LwR for more information.

Basically this allows  // until end of line and
/*    */ comments in any place where whitespace is allowed.